### PR TITLE
chore: disable test in debug stage

### DIFF
--- a/.goreleaser.debug.yaml
+++ b/.goreleaser.debug.yaml
@@ -6,7 +6,6 @@ before:
     - go generate
     - go run github.com/google/go-licenses@latest check . --disallowed_types=restricted
     - go mod tidy
-    - go test -race -v ./... -timeout 30m
 builds:
   - id: casaos-app-management-amd64
     binary: build/sysroot/usr/bin/casaos-app-management


### PR DESCRIPTION
I remove the test code in debug. Because I think it is unnecessary. In debug stage，I often change the code and build the code. If I want to run the test. I can run `go test -race -v ./... -timeout 30m` manually.  So I think the compulsory test wastes my time. 

I think these cases need to test. the case means the code is in a near-complete stage.
- a new PR
- release a new version