### PR TITLE
feat: not to reassign a value compose app env var

### DIFF
--- a/service/compose_app.go
+++ b/service/compose_app.go
@@ -371,7 +371,11 @@ func (a *ComposeApp) Pull(ctx context.Context) error {
 func injectEnvVariableToComposeApp(a *ComposeApp) {
 	for _, service := range a.Services {
 		for k, v := range baseEnvironmentMap() {
-			service.Environment[k] = &v
+			// if there is same name var declared in environment in compose yaml
+			// we should not reassign a value to it.
+			if service.Environment[k] == nil {
+				service.Environment[k] = &v
+			}
 		}
 	}
 }

--- a/service/compose_app.go
+++ b/service/compose_app.go
@@ -376,11 +376,11 @@ func (a *ComposeApp) Pull(ctx context.Context) error {
 func injectEnvVariableToComposeApp(a *ComposeApp) {
 	for _, service := range a.Services {
 		for k, v := range config.Global {
-      // if there is same name var declared in environment in compose yaml
+			// if there is same name var declared in environment in compose yaml
 			// we should not reassign a value to it.
 			if service.Environment[k] == nil {
-			  service.Environment[k] = utils.Ptr(v)
-      }
+				service.Environment[k] = utils.Ptr(v)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# What does the PR do?
We always inject OPENAI_API_KEY to all compose apps. But in some cases, some apps may need to have specified OPENAI_API_KEY. So when the compose app yaml have declared same env var, Casasos should didn't to reassign a value to it.

# Test sample
```yaml
name: memos
services:
  memos:
    environment:
      PGID: $PGID
      PUID: $PUID
      TZ: $TZ
      OPENAI_API_KEY: "sk-xxxx-test-1234"
    image: neosmemo/memos:0.13.1
    deploy:
      resources:
        reservations:
          memory: 64M
    network_mode: bridge
    ports:
      - target: 5230
        published: 5230
        protocol: tcp
    restart: unless-stopped
    volumes:
      - type: bind
        source: /DATA/AppData/memos/memos
        target: /var/opt/memos
    x-casaos:
      envs:
        - container: PUID
          description:
            en_us: ""
        - container: PGID
          description:
            en_us: ""
        - container: TZ
          description:
            en_us: "timezone"
            zh_cn: "时区"
      ports:
        - container: "5230"
          description:
            en_us: WebUI HTTP Port
            zh_cn: WebUI HTTP 端口
      volumes:
        - container: /var/opt/memos
          description:
            en_us: memos data directory.
            zh_cn: memos 数据目录

x-casaos:
  architectures:
    - amd64
    - arm64
    - arm
  main: memos
  author: usememos Team
  category: Notes
  description:
    en_us: Memos is a lightweight, self-hosted memo hub. Open Source and Free forever.
    zh_cn: Memos 是一个轻量级的自托管Memos中心。 开源且永远免费。
  developer: usememos Team
  icon: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/icon.png
  screenshot_link:
    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-1.png
    - https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/screenshot-2.png
  tagline:
    en_us: Memos is a lightweight, self-hosted memo hub. Open Source and Free forever.
    zh_cn: Memos 是一个轻量级的自托管Memos中心。 开源且永远免费。
  thumbnail: https://cdn.jsdelivr.net/gh/IceWhaleTech/CasaOS-AppStore@main/Apps/Memos/thumbnail.png
  tips: {}
  title:
    en_us: useMemos
  port_map: 5230
```
![image](https://github.com/IceWhaleTech/CasaOS-AppManagement/assets/29306285/f7220fee-9654-49ec-bf0e-d0321d9faf59)

We can see the env var of the container is set by yaml instead of casasos.
