### PR TITLE
Support ".yaml" file extension in BuildCatalog

### DIFF
--- a/service/appstore.go
+++ b/service/appstore.go
@@ -351,7 +351,11 @@ func BuildCatalog(storeRoot string) (map[string]*ComposeApp, error) {
 
 		composeFile := filepath.Join(path, common.ComposeYAMLFileName)
 		if !file.Exists(composeFile) {
-			return nil
+			// retry with ".yaml" extension
+			composeFile = strings.TrimSuffix(composeFile, ".yml") + ".yaml"	
+			if !file.Exists(composeFile) {
+				return nil
+			}
 		}
 
 		composeYAML := file.ReadFullFile(composeFile)


### PR DESCRIPTION
I had an issue with Apps in my custom AppStore not being listed in the Store. 
It turned out that I accidentally had created files named "docker-compose.yaml" instead of "docker-compose.yml" (without the a).
This lead me to some long, unnecessary debugging...

Since both file extensions are officially supported by docker, I extended the code here to accept both.

This issue is kinda linked to: https://github.com/IceWhaleTech/CasaOS-UI/pull/188